### PR TITLE
Moved packagecloud requirement to its own class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class appcanary (
   validate_bool($service_manage)
 
   anchor { 'appcanary::begin': } ->
+  class { '::appcanary::prereq': } ->
   class { '::appcanary::install': } ->
   class { '::appcanary::config': } ~>
   class { '::appcanary::service': } ->

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,22 +1,9 @@
 #
 class appcanary::install inherits appcanary {
 
-  case $::operatingsystem {
-    'debian', 'ubuntu': {
-      $type = 'deb'
-    }
-    'RedHat', 'redhat', 'CentOS', 'centos', 'Amazon', 'Fedora', 'Scientific', 'OracleLinux', 'OEL': {
-      $type = 'rpm'
-    }
-  }
-
-  include packagecloud
-  packagecloud::repo { "appcanary/agent":
-    type => $type,
-  }
-
   package { 'appcanary':
     ensure => $package_ensure,
     name   => $package_name,
   }
+
 }

--- a/manifests/prereq.pp
+++ b/manifests/prereq.pp
@@ -1,0 +1,18 @@
+#
+class appcanary::prereq inherits appcanary {
+
+  case $::operatingsystem {
+    'debian', 'ubuntu': {
+      $type = 'deb'
+    }
+    'RedHat', 'redhat', 'CentOS', 'centos', 'Amazon', 'Fedora', 'Scientific', 'OracleLinux', 'OEL': {
+      $type = 'rpm'
+    }
+  }
+
+  include packagecloud
+  packagecloud::repo { "appcanary/agent":
+    type => $type,
+  }
+
+}


### PR DESCRIPTION
Moving packagecloud repo installation to it's own class and chaining it first in init.pp should resolve the issue with the module not always applying cleanly the first time.
