### PR TITLE
Fix agent.conf.erb for Puppet 4

### DIFF
--- a/templates/agent.conf.erb
+++ b/templates/agent.conf.erb
@@ -1,7 +1,7 @@
 # /etc/appcanary/agent.conf: Managed by puppet
 #
 # Get your API key at https://www.appcanary.com/settings
-api_key = "<%= api_key %>"
+api_key = "<%= @api_key %>"
 
 <% if operatingsystem == "Ubuntu" -%>
 [[files]]


### PR DESCRIPTION
Puppet 4 removed method access of instance variables in ERB templates,
so this module doesn't compile on Puppet 4 at the moment.

https://tickets.puppetlabs.com/browse/PUP-3282
