### PR TITLE
Package name can't be an array

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,7 @@ class appcanary (
   validate_array($paths)
   validate_absolute_path($config)
   validate_string($config_template)
-  validate_array($package_name)
+  validate_array($package_names)
   validate_string($package_ensure)
   validate_string($service_name)
   validate_bool($service_enable)

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,9 +1,8 @@
 #
 class appcanary::install inherits appcanary {
 
-  package { 'appcanary':
+  package { $package_names:
     ensure => $package_ensure,
-    name   => $package_name,
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,7 +5,7 @@ class appcanary::params {
   $paths           = []
   $config          = '/etc/appcanary/agent.conf'
   $config_template = 'appcanary/agent.conf.erb'
-  $package_name    = [ 'appcanary' ]
+  $package_names   = [ 'appcanary' ]
   $package_ensure  = 'present'
   $service_name    = 'appcanary'
   $service_enable  = true


### PR DESCRIPTION
The name parameter of a Package can't be an array, but you _can_ install
multiple packages by passing an array to the title, which is what I
assume was intended here.

Error this causes:

```
Error: Failed to apply catalog: Parameter name failed on Package[appcanary]: Name must be a String not Array at /etc/puppetlabs/code/environments/production/modules/appcanary/manifests/install.pp:4
```

After both open PRs are merged, this compiles successfully on Puppet 4.
